### PR TITLE
fix syntax in sample script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ else:
 pipe = DiffusionPipeline.from_pretrained(model_name, torch_dtype=torch_dtype)
 pipe = pipe.to(device)
 
-positive_magic = [
-    "en": "Ultra HD, 4K, cinematic composition." # for english prompt,
-    "zh": "超清，4K，电影级构图" # for chinese prompt,
-]
+positive_magic = {
+    "en": "Ultra HD, 4K, cinematic composition.", # for english prompt
+    "zh": "超清，4K，电影级构图" # for chinese prompt
+}
 
 # Generate image
 prompt = '''A coffee shop entrance features a chalkboard sign reading "Qwen Coffee 😊 $2 per cup," with a neon light beside it displaying "通义千问". Next to it hangs a poster showing a beautiful Chinese woman, and beneath the poster is written "π≈3.1415926-53589793-23846264-33832795-02384197".'''
@@ -211,3 +211,4 @@ If you'd like to get in touch with our research team, we'd love to hear from you
 If you have questions about this repository, feedback to share, or want to contribute directly, we welcome your issues and pull requests on GitHub. Your contributions help make Qwen-Image better for everyone. 
 
 If you're passionate about fundamental research, we're hiring full-time employees (FTEs) and research interns. Don't wait — reach out to us at fulai.hr@alibaba-inc.com
+


### PR DESCRIPTION
The `positive_magic` dict in the sample script currently uses invalid syntax, making the script non-executable. 
This PR fixes that.