### PR TITLE
add cache-dit support for Qwen-Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ WaveSpeed has deployed Qwen-Image on their platform from day 0, visit their [mod
 
 LiblibAI offers native support for Qwen-Image from day 0. Visit their [community](https://www.liblib.art/modelinfo/c62a103bd98a4246a2334e2d952f7b21?from=sd&versionUuid=75e0be0c93b34dd8baeec9c968013e0c) page for more details and discussions.
 
+### cache-dit
+
+cache-dit offers cache acceleration support for Qwen-Image with DBCache, TaylorSeer and Cache CFG. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/run_qwen_image.py) for more details.
 
 ## License Agreement
 


### PR DESCRIPTION
## cache-dit

cache-dit offers cache acceleration support for Qwen-Image with DBCache, TaylorSeer and Cache CFG. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/run_qwen_image.py) for more details.

### Baseline

<img width="1664" height="928" alt="qwen-image NONE" src="https://github.com/user-attachments/assets/ec47b631-573e-4ca1-96ea-5ec1ef53bedb" />

### cache-dit: F8B0 + TaylorSeer + Cache CFG: 1.5x Speed Up
<img width="1664" height="928" alt="qwen-image DBCACHE_F8B0W0T1O2_R0 12" src="https://github.com/user-attachments/assets/6bcea0a5-8d83-4354-adb1-553c9e84c07f" />
