### PR TITLE
Update Community Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ LiblibAI offers native support for Qwen-Image from day 0. Visit their [community
 
 ### Inference Acceleration Method: cache-dit
 
-cache-dit offers cache acceleration support for Qwen-Image with DBCache, TaylorSeer and Cache CFG. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/run_qwen_image.py) for more details.
+cache-dit offers cache acceleration support for Qwen-Image with DBCache, TaylorSeer and Cache CFG. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_qwen_image.py) for more details.
 
 ## License Agreement
 
@@ -331,6 +331,7 @@ If you're passionate about fundamental research, we're hiring full-time employee
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=QwenLM/Qwen-Image&type=Date)](https://www.star-history.com/#QwenLM/Qwen-Image&Date)
+
 
 
 


### PR DESCRIPTION
Update Community Support: cache-dit. The example has been moved to: https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_qwen_image.py